### PR TITLE
Coffeescript syntax highlighting

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -26,6 +26,9 @@ unlet! b:current_syntax
 " Include Erb syntax highlighting
 syn include @slimErb syntax/eruby.vim
 unlet! b:current_syntax
+" Include Coffeescript syntax highlighting, ignoring errors if it's missing
+silent! syn include @slimCoffee syntax/coffee.vim
+unlet! b:current_syntax
 
 " Include HTML 
 runtime! syntax/html.vim
@@ -45,6 +48,7 @@ syn match slimText /^\(\s*\)[`|'].*\(\n\1\s.*\)*/
 
 syn match slimFilter /\s*\w\+:\s*/ contained
 syn match slimJs /^\(\s*\)\<javascript:\>.*\(\n\1\s.*\)*/ contains=@htmlJavaScript,slimFilter
+syn match slimCoffee /^\(\s*\)\<coffee:\>.*\(\n\1\s.*\)*/ contains=@slimCoffee,slimFilter
 syn match slimHaml /^\(\s*\)\<haml:\>.*\(\n\1\s.*\)*/ contains=@slimHaml,slimFilter
 syn match slimErb  /^\(\s*\)\<erb:\>.*\(\n\1\s.*\)*/ contains=@slimErb,slimFilter
 


### PR DESCRIPTION
This tries to import a syntax/coffee.vim (https://github.com/kchmck/vim-coffee-script), silently ignoring it if it's missing.
