### PR TITLE
Aligning with rails.vim

### DIFF
--- a/ftdetect/slim.vim
+++ b/ftdetect/slim.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead *.slim set filetype=slim
+autocmd FileType slim set tabstop=2|set shiftwidth=2|set expandtab


### PR DESCRIPTION
Hello,

I updated the plugin to auto set the following:
- tabstop = 2
- shiftwidth = 2
- expandtab

These fall inline with rails.vim. 

Thanks,
Scott
