### PR TITLE
Fix highlighting problem with ruby output

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -30,7 +30,7 @@ unlet! b:current_syntax
 silent! syn include @slimCoffee syntax/coffee.vim
 unlet! b:current_syntax
 
-" Include HTML 
+" Include HTML
 runtime! syntax/html.vim
 unlet! b:current_syntax
 
@@ -38,7 +38,7 @@ setlocal iskeyword+=:
 
 syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{" end="}" contained contains=@slimRuby
 
-syn region slimRubyOutput start="=\s*" skip=",\s*" end=" " contained contains=@slimRuby
+syn region slimRubyOutput start="=\s*" skip=",\s*" end="$" contained contains=@slimRuby
 syn region slimHtml start="^\s*[^-=]\w" end="$" contains=htmlTagName,htmlArg,htmlString,slimInterpolation,slimRubyOutput keepend
 
 syn region slimRubyCode start="[-=]" end="$" contains=@slimRuby


### PR DESCRIPTION
Since ruby output is marked as starting from `=\s*` to a space, method calls without braces get highlighted incorrectly. For example:

```
body
  h1 = link_to page.name
```

In this case, `page.name` is highlighted incorrectly as HTML.

This pull request fixes the issue and, as far as I've checked, doesn't seem to introduce any regressions. I have no idea why the delimiter was a space, though, so it's possible I've overlooked some use case.
