### PR TITLE
Disable word wrapping on slim templates

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -58,5 +58,3 @@ hi def link slimFilter                 Special
 hi def link slimInterpolationDelimiter Delimiter
 
 let b:current_syntax = "slim"
-
-set tw=0


### PR DESCRIPTION
I was having a problem with vim sometimes wrapping lines in my slim templates, so this is a suggested fix.  I know this is a mirror, but people who use janus.vim and slim will go here
