### PR TITLE
Added support for =' output indicator

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -41,7 +41,8 @@ syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{" en
 syn region slimRubyOutput start="=\s*" skip=",\s*" end="$" contained contains=@slimRuby
 syn region slimHtml start="^\s*[^-=]\w" end="$" contains=htmlTagName,htmlArg,htmlString,slimInterpolation,slimRubyOutput keepend
 
-syn region slimRubyCode start="[-=]" end="$" contains=@slimRuby
+syn region slimRubyCode start="[-=][^']" end="$" contains=@slimRuby
+syn region slimRubyWhitespaceCode start="^\s*='"ms=e+1 end="$" contains=@slimRuby
 
 syn match slimComment /^\(\s*\)[/].*\(\n\1\s.*\)*/
 syn match slimText /^\(\s*\)[`|'].*\(\n\1\s.*\)*/


### PR DESCRIPTION
Should fix the unmatched quote highlighting error that this indicator was causing before.

Just a note, this only works in cases where the indicator occurs on it's own line. It does not work on the same line as an html tag. This renders the =' indicator usable at least, even if it isn't an optimal solution.
