### PR TITLE
Set 'commentstring' for comments in slim code

### DIFF
--- a/ftplugin/slim.vim
+++ b/ftplugin/slim.vim
@@ -6,3 +6,4 @@ let b:did_ftplugin = 1
 let b:undo_ftplugin = "setl isk<"
 
 setlocal iskeyword+=-
+setlocal commentstring=/%s


### PR DESCRIPTION
Used for [adding `foldmaker`s](http://vimdoc.sourceforge.net/htmldoc/options.html#'commentstring') and in some [commenting plugins](https://github.com/tpope/vim-commentary#faq).