### PR TITLE
Add 'script' syntax highlight

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -35,6 +35,7 @@ syn keyword slimDocType        contained html 5 1.1 strict frameset mobile basic
 syn match   slimDocTypeKeyword "^\s*\(doctype\)\s\+" nextgroup=slimDocType
 
 syn keyword slimTodo        FIXME TODO NOTE OPTIMIZE XXX contained
+syn keyword htmlTagName     contained script
 
 syn match slimTag           "\w\+"         contained contains=htmlTagName nextgroup=@slimComponent
 syn match slimIdChar        "#{\@!"        contained nextgroup=slimId


### PR DESCRIPTION
I noticed that `script` wasn't being highlighted (I know I can use `:javascript`, but sometimes it's way cleaner use `script src=""`
