### PR TITLE
fix clone url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ slim syntax highlighting for vim.
 3. Install slim-vim
 
         pushd ~/.vim/bundle; \
-        git clone git@github.com:slim-template/vim-slim.git; \
+        git clone git://github.com/slim-template/vim-slim.git; \
         popd
 
 


### PR DESCRIPTION
By avoiding the use of ssh, cloning is also possible on hosts with no github SSH keys available.
