### PR TITLE
Allow line continuation by backslash in ruby block

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -65,8 +65,8 @@ syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{" en
 syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{{" end="}}" contains=@hamlRubyTop containedin=javascriptStringS,javascriptStringD,slimWrappedAttrs
 syn match  slimInterpolationEscape "\\\@<!\%(\\\\\)*\\\%(\\\ze#{\|#\ze{\)"
 
-syn region slimRuby matchgroup=slimRubyOutputChar start="\s*[=]\==[']\=" skip=",\s*$" end="$" contained contains=@slimRubyTop keepend
-syn region slimRuby matchgroup=slimRubyChar       start="\s*-"           skip=",\s*$" end="$" contained contains=@slimRubyTop keepend
+syn region slimRuby matchgroup=slimRubyOutputChar start="\s*[=]\==[']\=" skip="\%\(,\s*\|\\\)$" end="$" contained contains=@slimRubyTop keepend
+syn region slimRuby matchgroup=slimRubyChar       start="\s*-"           skip="\%\(,\s*\|\\\)$" end="$" contained contains=@slimRubyTop keepend
 
 syn match slimComment /^\(\s*\)[/].*\(\n\1\s.*\)*/ contains=slimTodo
 syn match slimText    /^\(\s*\)[`|'].*\(\n\1\s.*\)*/


### PR DESCRIPTION
This makes `1` and `2` in the following line to be hilighted properly

```
- a \
  1
= b \
  2
```
