### PR TITLE
Use setf instead of set=

### DIFF
--- a/ftdetect/slim.vim
+++ b/ftdetect/slim.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.slim set filetype=slim
+autocmd BufNewFile,BufRead *.slim setf slim


### PR DESCRIPTION
```
:setf[iletype] {filetype}                       :setf :setfiletype
                        Set the 'filetype' option to {filetype}, but only if
                        not done yet in a sequence of (nested) autocommands.
                        This is short for:
                                :if !did_filetype()
                                :  setlocal filetype={filetype}
                                :endif
                        This command is used in a filetype.vim file to avoid
                        setting the 'filetype' option twice, causing different
                        settings and syntax files to be loaded.
```