### PR TITLE
fix typo: vbundle -> Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are already using pathogen, you can skip to step 3.
         popd
 
 
-Install with vbundle
+Install with Vundle
 --------------------
 
 1. [Install Vundle] into `~/.vim/bundle/`.


### PR DESCRIPTION
Its web site calls "Vundle".
https://github.com/gmarik/Vundle.vim