### PR TITLE
Ported various filters from HAML to Slim

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -66,6 +66,12 @@ syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{" en
 syn region slimInterpolation matchgroup=slimInterpolationDelimiter start="#{{" end="}}" contains=@hamlRubyTop containedin=javascriptStringS,javascriptStringD,slimWrappedAttrs
 syn match  slimInterpolationEscape "\\\@<!\%(\\\\\)*\\\%(\\\ze#{\|#\ze{\)"
 
+syn region slimPlainFilter      matchgroup=slimFilter start="^\z(\s*\)\%(rdoc\|textile\|markdown\|wiki\):\s*$" end="^\%(\z1 \| *$\)\@!"
+syn region slimJavascriptFilter matchgroup=slimFilter start="^\z(\s*\)javascript:\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlJavaScript,slimInterpolation keepend
+syn region slimCoffeeFilter matchgroup=slimFilter start="^\z(\s*\)coffee:\s*$" end="^\%(\z1 \| *$\)\@!" contains=@coffeeAll,slimInterpolation keepend
+syn region slimCSSFilter matchgroup=slimFilter start="^\z(\s*\)css:\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlCss,slimInterpolation keepend
+syn region slimSassFilter matchgroup=slimFilter start="^\z(\s*\)sass:\s*$" end="^\%(\z1 \| *$\)\@!" contains=@hamlSassTop
+
 syn region slimRuby matchgroup=slimRubyOutputChar start="\s*[=]\==[']\=" skip="\%\(,\s*\|\\\)$" end="$" contained contains=@slimRubyTop keepend
 syn region slimRuby matchgroup=slimRubyChar       start="\s*-"           skip="\%\(,\s*\|\\\)$" end="$" contained contains=@slimRubyTop keepend
 
@@ -98,5 +104,6 @@ hi def link slimTodo                      Todo
 hi def link slimWrappedAttrValueDelimiter Delimiter
 hi def link slimWrappedAttrsDelimiter     Delimiter
 hi def link slimInlineTagChar             Delimiter
+hi def link slimFilter                    PreProc
 
 let b:current_syntax = "slim"


### PR DESCRIPTION
Hi, i've noticed the missing highlighting for embedded languages, such as JS + CSS. I've "ported" the highlighting code from HAML (see https://github.com/tpope/vim-haml/blob/master/syntax/haml.vim#L62).

* Plain (Textile/Markdown/Wiki/Doc)
* JS + Coffee
* CSS + Sass

![bildschirmfoto 2016-02-02 um 16 54 06](https://cloud.githubusercontent.com/assets/147175/12754927/9ab03b78-c9cd-11e5-9dd3-5f5db3dc1f07.png)

Maybe interesting for @evantravers, who started a branch on his own, implementing the plain filters.