### PR TITLE
Load ruby ftplugin in slim ftplugin

### DIFF
--- a/ftplugin/slim.vim
+++ b/ftplugin/slim.vim
@@ -1,9 +1,25 @@
 if exists("b:did_ftplugin")
   finish
 endif
+
+" Define some defaults in case the included ftplugins don't set them.
+let s:undo_ftplugin = ""
+
+" Override our defaults if these were set by an included ftplugin.
+if exists("b:undo_ftplugin")
+  let s:undo_ftplugin = b:undo_ftplugin
+  unlet b:undo_ftplugin
+endif
+
+runtime! ftplugin/ruby.vim ftplugin/ruby_*.vim ftplugin/ruby/*.vim
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl isk<"
+" Combine the new set of values with those previously included.
+if exists("b:undo_ftplugin")
+  let s:undo_ftplugin = b:undo_ftplugin . " | " . s:undo_ftplugin
+endif
+
+let b:undo_ftplugin = "setl isk<" . " | " . s:undo_ftplugin
 
 setlocal iskeyword+=-
 setlocal commentstring=/%s


### PR DESCRIPTION
This will load mappings from vim-rails and co.
This will give you access to mappings from `vim-rails` such as `gf` on partials.
I'm not a professional vimscripter but i think this is the right way of doing it.

Was told by timpope that this should be done here in: https://github.com/tpope/vim-rails/issues/524