### PR TITLE
accept colons and slashes for tailwind compatibility

### DIFF
--- a/syntax/slim.vim
+++ b/syntax/slim.vim
@@ -41,7 +41,7 @@ syn match slimTag           "\w\+[><]*"         contained contains=htmlTagName n
 syn match slimIdChar        "#{\@!"        contained nextgroup=slimId
 syn match slimId            "\%(\w\|-\)\+" contained nextgroup=@slimComponent
 syn match slimClassChar     "\."           contained nextgroup=slimClass
-syn match slimClass         "\%(\w\|-\)\+" contained nextgroup=@slimComponent
+syn match slimClass         "\%(\w\|-\|\/\d+\|:\(\w\|-\)\+\)\+" contained nextgroup=@slimComponent
 syn match slimInlineTagChar "\s*:\s*"      contained nextgroup=slimTag,slimClassChar,slimIdChar
 
 syn region slimWrappedAttrs matchgroup=slimWrappedAttrsDelimiter start="\s*{\s*" skip="}\s*\""  end="\s*}\s*"  contained contains=slimAttr nextgroup=slimRuby


### PR DESCRIPTION
This will let tailwind syntax highlight correctly. For details see [this commit to slim](https://github.com/slim-template/slim/commit/b5e2cdac03b28dd4d8d4b8727308f7aa0d14d07f).